### PR TITLE
Update dependencies to work with Clojure 1.9

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,10 @@
 (defproject clj-campfire "2.2.0"
   :description "thin wrapper for Campfire's API"
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [http.async.client "0.5.2"]
+                 [http.async.client "1.2.0"]
                  [cheshire "5.1.0"]]
   :profiles {:dev 
-             {:plugins [[lein-midje "3.0.0"]]
-              :dependencies [[midje "1.5.1"]]}})
+             {:plugins [[lein-midje "3.2.1"]]
+              :dependencies [[org.clojure/clojure "1.9.0"]
+                             [midje "1.6.0"]
+                             [org.clojure/core.unify "0.5.7"]]}})


### PR DESCRIPTION
The following projects have been updated to be compatible with Clojure 1.9:

- org.clojure/core.unify
- http.async.client
- midje

The versions in use prior to this change had problems with their use of `ns`
or `defn` macros that were caught by spec in Clojure 1.9.